### PR TITLE
KernelConfig.mk: allow kernel to be built from sources

### DIFF
--- a/KernelConfig.mk
+++ b/KernelConfig.mk
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BUILD_KERNEL := false
-
 ifeq ($(BUILD_KERNEL),false)
 
 LOCAL_KERNEL := $(KERNEL_PATH)/common-kernel/kernel-dtb-$(TARGET_DEVICE)


### PR DESCRIPTION
BUILD_KERNEL is controlled via device/sony/common/CommonConfig.mk
setting it here would overwrite the CommonConfig.mk value and force
a prebuilt kernel.

Signed-off-by: Franz-Josef Haider <franz.haider@jollamobile.com>

Didn't notice this until now, since my manifest excluded this repository. Let me know if this is needed on other branches as well.